### PR TITLE
replaces events hash with actions hash

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,9 +15,9 @@
         <div class="navbar-inner">
           <a class="brand" href="#">Ember Digest</a>
           <ul class="nav pull-right">
-            <li>{{#linkTo articles}}Articles{{/linkTo}}</li>
-            <li>{{#linkTo photos}}Photos{{/linkTo}}</li>
-            <li>{{#linkTo login}}Login{{/linkTo}}</li>
+            <li>{{#linkTo 'articles'}}Articles{{/linkTo}}</li>
+            <li>{{#linkTo 'photos'}}Photos{{/linkTo}}</li>
+            <li>{{#linkTo 'login'}}Login{{/linkTo}}</li>
           </ul>
         </div>
       </div>
@@ -63,7 +63,7 @@
     {{#if loggedIn}}
       <p>You are already logged in!</p>
     {{else}}
-      <form class="form-inline" {{action login on="submit"}}>
+      <form class="form-inline" {{action 'login' on="submit"}}>
         <h2>Log In</h2>
         {{input value=username type="text" placeholder="Username"}}
         {{input value=password type="password" placeholder="Password"}}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -35,7 +35,7 @@ App.AuthenticatedRoute = Ember.Route.extend({
     return $.getJSON(url, { token: token });
   },
 
-  events: {
+  actions: {
     error: function(reason, transition) {
       if (reason.status === 401) {
         this.redirectToLogin(transition);

--- a/server.js
+++ b/server.js
@@ -61,7 +61,7 @@ function validTokenProvided(req, res) {
   var userToken = req.body.token || req.param('token') || req.headers.token;
 
   if (!currentToken || userToken != currentToken) {
-    res.send(401, { error: 'Invalid token. You provided: ' + userToken });
+    res.status(401).send({ error: 'Invalid token. You provided: ' + userToken });
     return false;
   }
 


### PR DESCRIPTION
I was following the screen cast and noticed this. I think event hash is deprecated in ember and is replaced with actions hash (correct me if I am wrong).
